### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -660,7 +660,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token %s", maskToken(authz))
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)
@@ -680,6 +680,13 @@ func authnMiddleware(next http.Handler) http.Handler {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 
 	})
+}
+
+func maskToken(token string) string {
+	if len(token) <= 4 {
+		return "****"
+	}
+	return "****" + token[len(token)-4:]
 }
 
 func main() {


### PR DESCRIPTION
Potential fix for [https://github.com/latekpro/ghas-test/security/code-scanning/4](https://github.com/latekpro/ghas-test/security/code-scanning/4)

To fix the issue, we should avoid logging the sensitive `Authorization` header in plain text. Instead, we can log a sanitized or obfuscated version of the header, such as by masking most of the token while retaining a small portion (e.g., the last few characters) for debugging purposes. This approach ensures that sensitive information is not exposed in the logs while still providing enough context for debugging.

The changes involve:
1. Modifying the logging statement on line 663 to obfuscate the `authz` value.
2. Introducing a helper function to mask sensitive data, if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
