### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -17,6 +17,13 @@ import (
 
 )
 
+func maskToken(token string) string {
+	if len(token) <= 4 {
+		return "****"
+	}
+	return token[:4] + strings.Repeat("*", len(token)-4)
+}
+
 type Configuration struct {
 	Host 		string	`json:"host"`
 	Port 		int		`json:"port"`
@@ -641,7 +648,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token %s", maskToken(tokenString))
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {


### PR DESCRIPTION
Potential fix for [https://github.com/latekpro/ghas-test/security/code-scanning/3](https://github.com/latekpro/ghas-test/security/code-scanning/3)

To fix the issue, we should avoid logging the sensitive `tokenString` in plaintext. Instead, we can mask or obfuscate the token before logging it. A common approach is to log only the first few characters of the token (e.g., the first 4 characters) and replace the rest with asterisks (`*`). This allows for debugging while protecting the sensitive data.

To implement this:
1. Introduce a helper function, `maskToken`, that takes a token string as input and returns a masked version of the token.
2. Replace the logging of `tokenString` on line 644 with a call to `maskToken` to log the masked version of the token.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
