### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -197,13 +197,13 @@ func (g *Gallery) Create(profile *OctoProfile) error {
 func (g Gallery) Update(profile *OctoProfile) error {
 	db := GetDb()
 
-	stmt, err := db.Prepare(fmt.Sprintf("UPDATE gallery SET title = '%s', description = '%s' WHERE id = %d and login = '%s'", g.Title, g.Description, g.ID, profile.Login))
+	stmt, err := db.Prepare("UPDATE gallery SET title = ?, description = ? WHERE id = ? and login = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	r , err := stmt.Exec()
+	r, err := stmt.Exec(g.Title, g.Description, g.ID, profile.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/latekpro/ghas-test/security/code-scanning/2](https://github.com/latekpro/ghas-test/security/code-scanning/2)

To fix the issue, the query should be rewritten to use parameterized queries instead of string concatenation. This involves replacing the `fmt.Sprintf`-constructed query with a query string that uses placeholders (`?`) for parameters, and then passing the actual values as arguments to the `Exec` method. This approach ensures that the database driver safely escapes and handles the input, preventing SQL injection.

Specifically:
1. Replace the `fmt.Sprintf` query construction with a parameterized query string.
2. Pass `g.Title`, `g.Description`, `g.ID`, and `profile.Login` as arguments to the `Exec` method.
3. Ensure no other changes to the functionality of the `Update` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
